### PR TITLE
Fix error instanceof

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,9 +1,9 @@
 const {
-  readDir,
+  readdir,
   readlink,
   lstatSync,
   lstat,
-  readDirSync,
+  readdirSync,
   readlinkSync,
 } = Deno;
 
@@ -253,7 +253,7 @@ async function walk(
       continue;
     }
     if (info.isDirectory()) {
-      const files = await readDir(path);
+      const files = await readdir(path);
       promises.push(walk(prev, curr, files, followSymlink, filter, changes));
     } else if (info.isFile()) {
       if (curr[path]) {
@@ -307,7 +307,7 @@ function collect(
       continue;
     }
     if (info.isDirectory()) {
-      collect(all, readDirSync(path), followSymlink, filter);
+      collect(all, readdirSync(path), followSymlink, filter);
     } else if (info.isFile()) {
       all[path] = info.modified || info.created;
     }

--- a/mod.ts
+++ b/mod.ts
@@ -1,14 +1,15 @@
-import {
+const {
   readDir,
   readlink,
   lstatSync,
   lstat,
   readDirSync,
   readlinkSync,
-  FileInfo,
   DenoError,
   ErrorKind
-} from "deno";
+} = Deno;
+
+type FileInfo = Deno.FileInfo;
 
 /** The result of checking in one loop */
 export class Changes {

--- a/mod.ts
+++ b/mod.ts
@@ -5,8 +5,6 @@ const {
   lstat,
   readDirSync,
   readlinkSync,
-  DenoError,
-  ErrorKind
 } = Deno;
 
 type FileInfo = Deno.FileInfo;
@@ -242,7 +240,7 @@ async function walk(
         info = f;
       }
     } catch (e) {
-      if (e instanceof DenoError && e.kind === ErrorKind.NotFound) {
+      if (e instanceof Deno.errors.NotFound) {
         continue;
       } else {
         throw e;
@@ -296,7 +294,7 @@ function collect(
         info = f;
       }
     } catch (e) {
-      if (e instanceof DenoError && e.kind === ErrorKind.NotFound) {
+      if (e instanceof Deno.errors.NotFound) {
         continue;
       } else {
         throw e;


### PR DESCRIPTION
Building of the pull request of briefguo, (#6), fixing rename of `readdir` and `readdirSync` (don't now at which version they are changed, but `dir` is written with lowercase in the current Deno version), and how to check which error that is thrown.